### PR TITLE
Add flags and extensions

### DIFF
--- a/message-index/messages/GHC-05989/index.md
+++ b/message-index/messages/GHC-05989/index.md
@@ -4,8 +4,8 @@ summary: A type constructor is declared with more arguments than its kind
     annotation specifies.
 introduced: 9.6.1
 severity: error
+extension: StandaloneKindSignatures
 ---
 
 This error means that a type constructor is declared with more arguments than
-are specified in a corresponding standalone kind signature (using
-`StandaloneKindSignatures`).
+are specified in a corresponding standalone kind signature.

--- a/message-index/messages/GHC-20125/index.md
+++ b/message-index/messages/GHC-20125/index.md
@@ -3,5 +3,6 @@ title: Missing Fields
 summary: Initialization of record with missing fields
 severity: warning
 introduced: 9.6.1
+flag: -Wmissing-fields
 ---
 When constructing a record using labeled fields, all fields which are not explicitly stated are implicitly initialized with a bottom term. This means that accessing the field results in a panic.

--- a/message-index/messages/GHC-30606/index.md
+++ b/message-index/messages/GHC-30606/index.md
@@ -3,6 +3,8 @@ title: Redundant constraints
 summary: A binding has constraints that are redundant.
 introduced: 9.6.1
 severity: warning
+flag: -Wredundant-constraints
+flagset: -Weverything
 ---
 
 This warning is emitted when a binding has a type signature which contains

--- a/message-index/messages/GHC-62161/index.md
+++ b/message-index/messages/GHC-62161/index.md
@@ -3,6 +3,8 @@ title: Incomplete Patterns
 summary: Pattern match(es) are non-exhaustive
 severity: warning
 introduced: 9.6.1
+flag: -fwarn-incomplete-patterns
+flagset: -W
 ---
 
 A function definition or `case` expression did not cover all cases. This may

--- a/message-index/templates/message.html
+++ b/message-index/templates/message.html
@@ -1,3 +1,17 @@
+$if(flag)$
+<p>
+  <i>Flag: <code>$flag$</code></i>
+  $if(flagset)$
+  (included in <code>$flagset$</code>)
+  $else$
+  (on by default)
+  $endif$
+</p>
+$endif$
+$if(extension)$
+<p><i>Language extension: <code>$extension$</code></i></p>
+$endif$
+
 $body$
 
 <h2>Examples</h2>


### PR DESCRIPTION
This adds a few more fields:

- `extension`: to indicate that the error message is related to a language extension
- `flag`: to indicate it's related to a flag,
- `flagset`: to indicate the [flag set](https://downloads.haskell.org/ghc/latest/docs/html/users_guide/using-warnings.html) the flag is part of.