### PR TITLE
Crossreference the errors for missing strict and lazy fields

### DIFF
--- a/message-index/messages/GHC-20125/index.md
+++ b/message-index/messages/GHC-20125/index.md
@@ -6,3 +6,5 @@ introduced: 9.6.1
 flag: -Wmissing-fields
 ---
 When constructing a record using labeled fields, all fields which are not explicitly stated are implicitly initialized with a bottom term. This means that accessing the field results in a panic.
+
+If a *strict* field is missing, the error [GHC-95909](/messages/GHC-95909/index.html) is emitted instead.

--- a/message-index/messages/GHC-95909/index.md
+++ b/message-index/messages/GHC-95909/index.md
@@ -8,3 +8,5 @@ introduced: 9.6.1
 When strict fields are in use for a datatype -- either per-field with `BangPatterns` or for an entire type using the language extensions `Strict`/`StrictData` -- all fields are strictly evaluated by constructors. Therefore, it is not possible to leave some fields unassigned, because they can't be given a suspended bottom as a placeholder.
 
 Therefore, it is required that *all* strict fields for a constructor are assigned on construction of the type.
+
+If a *lazy* field is missing, the warning [GHC-20125](/messages/GHC-20125/index.html) is emitted instead.


### PR DESCRIPTION
I'm not sure if there is a better way to specify links between files, but this one works locally on my computer.