### PR TITLE
Automatically deploy to GitHub pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+
+  build-and-test:
+    name: Build site
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Haskell
+      uses: haskell/actions/setup@v2
+
+    - name: Check out repo
+      uses: actions/checkout@v3
+      
+    - name: Read the Cabal cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cabal/store
+          message-index/dist-newstyle
+        key: cabal-cache-${{ github.sha }}
+        restore-keys: |
+          cabal-cache
+
+    - name: Update the Cabal index
+      run: cabal update
+
+    - name: Build with Hakyll
+      working-directory: message-index
+      run: cabal run site build
+
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      if: ${{ github.ref == 'refs/heads/main' }}
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./message-index/_site

--- a/message-index/templates/default.html
+++ b/message-index/templates/default.html
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="robots" content="noindex">
         <title>$title$ — Haskell Error Index</title>
         <link rel="stylesheet" href="/css/default.css" />
     </head>


### PR DESCRIPTION
This PR contains a GitHub workflow which deploys the index to `haskell.github.io/error-messages`. Some notes:

- The first time it runs it will take a lot of time, because it needs to build Hakyll. The result is then saved on the GitHub cache, so that next PRs don't need to do so.
- After the first successful run, somebody with Admin access needs to enable Pages in the _Settings_. Please choose `gh-pages` as the branch and `/ (root)` as the folder.