### PR TITLE
Fix indentation for GHC-84077

### DIFF
--- a/message-index/messages/GHC-84077/example1/index.md
+++ b/message-index/messages/GHC-84077/example1/index.md
@@ -1,16 +1,16 @@
 ---
- title: Missing space before type application
- ---
+title: Missing space before type application
+---
 
- There is no space before the type application `@Int`.
+There is no space before the type application `@Int`.
 
- ## Error Message
+## Error Message
 
- ```
- MissingSpaceTypeOperator.hs:6:7: error:
-     @-pattern in expression context: x@Int
-     Type application syntax requires a space before '@'
-   |
- 6 | f x = x@Int
-   |       ^^^^^
- ```
+```
+MissingSpaceTypeOperator.hs:6:7: error:
+    @-pattern in expression context: x@Int
+    Type application syntax requires a space before '@'
+  |
+6 | f x = x@Int
+  |       ^^^^^
+```

--- a/message-index/messages/GHC-84077/example2/index.md
+++ b/message-index/messages/GHC-84077/example2/index.md
@@ -1,18 +1,18 @@
 ---
- title: Missing space in type application
- ---
+title: Missing space in type application
+---
 
- ## Error Message
+## Error Message
 
- ```
+```
 Example.hs:7:5: error:
     @-pattern in expression context: g@Int
     Type application syntax requires a space before '@'
   |
 7 | f = g@Int
   |     ^^^^^
- ```
+```
 
- ## Explanation
+## Explanation
 
- A space is missing before the type application. The expression cannot be correctly parsed.
+A space is missing before the type application. The expression cannot be correctly parsed.


### PR DESCRIPTION
Currently the example of GHC-84077 looks like this:
![image](https://user-images.githubusercontent.com/7516482/173227415-8788e5bd-52ed-4596-9404-489ff0ce59e8.png)
The correct indentation should fix this