### PR TITLE
Clean up GHC-95909, fix terminology

### DIFF
--- a/message-index/messages/GHC-95909/example1/after/MissingStrictField.hs
+++ b/message-index/messages/GHC-95909/example1/after/MissingStrictField.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
-
-module StringBangPatterns where
+module MissingStrictField where
 
 data A = A
     { a :: !Bool

--- a/message-index/messages/GHC-95909/example1/before/MissingStrictField.hs
+++ b/message-index/messages/GHC-95909/example1/before/MissingStrictField.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
-
-module StrictBangPatterns where
+module MissingStrictField where
 
 data A = A
     { a :: !Bool

--- a/message-index/messages/GHC-95909/example1/index.md
+++ b/message-index/messages/GHC-95909/example1/index.md
@@ -2,12 +2,12 @@
 title: Missing strict field in record syntax
 ---
 
-The instantiation of a strict field in a record is missing. In `aFine`, we can leave one field uninstantiated as it is not strict, and therefore is not evaluated to `undefined` (due to lazy evaluation). However in `aBad` we cannot, as the field `a` is strict.
+The instantiation of a strict field in a record is missing. In `aFine`, we can leave one field uninstantiated as it is not strict, and therefore is not evaluated until needed, due to lazy evaluation. However in `aBad` we cannot, as the field `a` is strict.
 
 ## Error Message
 
 ```
-StrictBangPatterns.hs:12:8: error: [GHC-95909]
+MissingStrictField.hs:12:8: error: [GHC-95909]
     • Constructor ‘A’ does not have the required strict field(s): a
     • In the expression: A {b = 5}
       In an equation for ‘aBad’: aBad = A {b = 5}

--- a/message-index/messages/GHC-95909/example2/index.md
+++ b/message-index/messages/GHC-95909/example2/index.md
@@ -1,8 +1,8 @@
 ---
-title: All fields are strict without explicit bang patterns if the language extension is enabled
+title: All fields are strict if the StrictData language extension is enabled
 ---
 
-When using the language extension `{-# LANGUAGE Strict #-}` or `{-# LANGUAGE StrictData #-}`, all fields are strict, even if we do not explicitly use the strictness bang pattern `!`. Thus, we must instantiate all fields on construction.
+When using the language extension `{-# LANGUAGE Strict #-}` or `{-# LANGUAGE StrictData #-}`, all fields are strict, even if we do not explicitly use the strictness flag `!`. Thus, we must instantiate all fields on construction.
 
 ## Error Message
 

--- a/message-index/messages/GHC-95909/index.md
+++ b/message-index/messages/GHC-95909/index.md
@@ -1,12 +1,12 @@
 ---
 title: Missing strict fields
-summary: Constructor does not have required strict field(s)
+summary: Constructor was not instantiated with required strict field(s)
 severity: error
 introduced: 9.6.1
 ---
 
-When strict fields are in use for a datatype -- either per-field with `BangPatterns` or for an entire type using the language extensions `Strict`/`StrictData` -- all fields are strictly evaluated by constructors. Therefore, it is not possible to leave some fields unassigned, because they can't be given a suspended bottom as a placeholder.
+When strict fields are declared for a datatype -- either per-field with a strictness flag `!`,  or for an entire type using the language extensions `Strict`/`StrictData` -- all strict fields are strictly evaluated by constructors. Therefore, it is not possible to leave some strict fields unassigned, because they can't be given a suspended bottom as a placeholder.
 
 Therefore, it is required that *all* strict fields for a constructor are assigned on construction of the type.
 
-If a *lazy* field is missing, the warning [GHC-20125](/messages/GHC-20125/index.html) is emitted instead.
+If a *non-strict* field is missing, the warning [GHC-20125](/messages/GHC-20125/index.html) is emitted instead.


### PR DESCRIPTION
Some clean up of the terminology used, the main change being that the stricness flags used to declare strict fields are not bang patterns, and do not require the `BangPatterns` extension.