### PR TITLE
Make title case and summary sentence fullstops consistent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,8 +90,8 @@ example message description:
 
 ````markdown
 ---
-title: Unification Error
-summary: Two types that should match are in conflict
+title: Unification error
+summary: Two types that should match are in conflict.
 introduced: 9.4.1
 severity: error
 ---
@@ -107,9 +107,9 @@ Unification error: Expected type A but got type B
 ```
 ````
 
-The fields in the metadata block should be: 
- * `title` - a short title used for the page header and for links to the description
- * `summary` - a short summary used in the message index
+The fields in the metadata block should be:
+ * `title` - a short title used for the page header and for links to the description, in regular sentence case (First word capitalised only, no ending `.`)
+ * `summary` - a short summary used in the message index, in regular sentence case (and finished with a `.`)
  * `introduced` - the tool version in which the error code was introduced (optional)
  * `removed` - if the message was removed, the first version which no longer produces this message (optional)
  * `flag` - the flag which enables this warning (optional)

--- a/message-index/messages/GHC-10190/index.md
+++ b/message-index/messages/GHC-10190/index.md
@@ -1,6 +1,6 @@
 ---
 title: Empty enumeration
-summary: An enumeration would be empty
+summary: An enumeration would be empty.
 introduced: 9.6.1
 severity: warning
 ---

--- a/message-index/messages/GHC-11913/index.md
+++ b/message-index/messages/GHC-11913/index.md
@@ -1,6 +1,6 @@
 ---
 title: Illegal deriving item
-summary: Something other than a type class appears in a deriving statement
+summary: Something other than a type class appears in a deriving statement.
 introduced: 9.6.1
 severity: error
 ---

--- a/message-index/messages/GHC-20125/index.md
+++ b/message-index/messages/GHC-20125/index.md
@@ -1,6 +1,6 @@
 ---
-title: Missing Fields
-summary: Initialization of record with missing fields
+title: Missing field(s)
+summary: Initialization of record with missing field(s).
 severity: warning
 introduced: 9.6.1
 flag: -Wmissing-fields

--- a/message-index/messages/GHC-27207/index.md
+++ b/message-index/messages/GHC-27207/index.md
@@ -1,6 +1,6 @@
 ---
 title: Missing space after tilde `~`
-summary: Lazy pattern in expression context
+summary: Lazy pattern in expression context.
 severity: error
 introduced: 9.6.1
 ---

--- a/message-index/messages/GHC-62161/index.md
+++ b/message-index/messages/GHC-62161/index.md
@@ -1,6 +1,6 @@
 ---
-title: Incomplete Patterns
-summary: Pattern match(es) are non-exhaustive
+title: Incomplete patterns
+summary: Pattern match(es) are non-exhaustive.
 severity: warning
 introduced: 9.6.1
 flag: -fwarn-incomplete-patterns

--- a/message-index/messages/GHC-84077/index.md
+++ b/message-index/messages/GHC-84077/index.md
@@ -1,7 +1,7 @@
 ---
-title: Type Application Without Space
-summary:  Parsing error of type application
-introduced: 9.4.1
+title: Type application without space
+summary:  Parsing error of type application.
+introduced: 9.6.1
 severity: error
 ---
 

--- a/message-index/messages/GHC-88464/index.md
+++ b/message-index/messages/GHC-88464/index.md
@@ -1,6 +1,6 @@
 ---
 title: Variable not in scope
-summary: An unknown variable name was referenced
+summary: An unknown variable name was referenced.
 introduced: 9.6.1
 severity: error
 ---

--- a/message-index/messages/GHC-95644/index.md
+++ b/message-index/messages/GHC-95644/index.md
@@ -1,6 +1,6 @@
 ---
-title: Missing space after exclamation `!`
-summary: Bang pattern in expression context
+title: Missing space after exclamation mark `!`
+summary: Bang pattern in expression context.
 severity: error
 introduced: 9.6.1
 ---

--- a/message-index/messages/GHC-95909/index.md
+++ b/message-index/messages/GHC-95909/index.md
@@ -1,6 +1,6 @@
 ---
 title: Missing strict fields
-summary: Constructor does not have required strict field(s)
+summary: Constructor does not have required strict field(s).
 severity: error
 introduced: 9.6.1
 ---


### PR DESCRIPTION
this adds a `.` to the summaries (as they are meant to be individual sentences) and unifies everything to `This kind of title case` as again, they are sentences rather than headlines