### PR TITLE
Fix improper use of the term bang pattern in GHC-95644

### DIFF
--- a/message-index/messages/GHC-95644/index.md
+++ b/message-index/messages/GHC-95644/index.md
@@ -6,7 +6,10 @@ introduced: 9.6.1
 ---
 
 The `!` character can be used for multiple purposes:
-- As a binary operator `(!) :: a -> b -> c`
-- As a *bang pattern* when defining fields or variable bindings `let !l = ...`
+
+- As a binary operator: `(!) :: a -> b -> c`
+- As a *strictness flag* when defining fields: `data Foo = MkFoo !Int Char`
+- To write strict let bindings: `let !b = undefined in (True, b)`
+- As a *bang pattern* to make patterns stricter: `let (!a,b) = (undefined, True) in b || a`
 
 If no space is placed between `!` and the expression that follows it, this is interpreted as the last bullet; in expression contexts, the bang pattern is not allowed. The most likely case is that you wish to use `!` as a binary operator, in which case a space is needed following it.


### PR DESCRIPTION
Neither of the examples given in GHC-95644 are bang patterns. In this commit I've fixed the terminology and added an actual example of a bang pattern.