### PR TITLE
Show examples inline

### DIFF
--- a/message-index/css/default.css
+++ b/message-index/css/default.css
@@ -207,3 +207,17 @@ nav#breadcrumb a {
 table pre {
   margin: 0;
 }
+
+details {
+  margin-bottom: 10px;
+}
+
+summary {
+  font-size: large;
+  font-style: italic;
+}
+
+.example-container {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}

--- a/message-index/site.hs
+++ b/message-index/site.hs
@@ -83,11 +83,10 @@ main = hakyll $ do
                         field "after" (maybe (pure "<not present>") (fmap itemBody . load . itemIdentifier) . view _3 . itemBody)
                       ]
                   )
-                  (return [Item (fromFilePath name) (name, before, after) | (name, before, after) <- files]),
+                  (return files),
                 defaultContext
               ]
           )
-        >>= loadAndApplyTemplate "templates/default.html" (bread <> defaultContext)
         >>= relativizeUrls
 
   match "messages/*/index.md" $
@@ -101,7 +100,9 @@ main = hakyll $ do
       examples <- getExamples
       bread <- breadcrumbField ["index.html", "messages/index.md"]
       pandocCompiler
-        >>= loadAndApplyTemplate "templates/message.html" (listField "examples" defaultContext (pure examples) <> defaultContext)
+        >>= loadAndApplyTemplate "templates/message.html" 
+              (listField "examples" defaultContext (pure examples)
+              <> defaultContext)
         >>= loadAndApplyTemplate "templates/default.html" (bread <> defaultContext)
         >>= relativizeUrls
 
@@ -196,7 +197,7 @@ getExamples = do
     other -> fail $ "Not processing a message: " ++ show other
   loadAll $ fromGlob ("messages/" <> code <> "/*/index.*") .&&. hasNoVersion
 
-getExampleFiles :: Compiler [(FilePath, Maybe (Item String), Maybe (Item String))]
+getExampleFiles :: Compiler [Item (FilePath, Maybe (Item String), Maybe (Item String))]
 getExampleFiles = do
   me <- getUnderlying
   (id, exampleName) <- case splitDirectories $ toFilePath me of
@@ -206,13 +207,14 @@ getExampleFiles = do
   before <- loadAll (fromGlob ("messages/" <> id <> "/" <> exampleName <> "/before/*.hs") .&&. hasVersion "raw")
   after <- loadAll (fromGlob ("messages/" <> id <> "/" <> exampleName <> "/after/*.hs") .&&. hasVersion "raw")
   let allNames = sort $ nub $ map (takeFileName . toFilePath . itemIdentifier) $ before ++ after
-  pure
-    [ ( name,
-        find ((== name) . takeFileName . toFilePath . itemIdentifier) before,
-        find ((== name) . takeFileName . toFilePath . itemIdentifier) after
-      )
-      | name <- allNames
-    ]
+  pure $ 
+      [ Item (fromFilePath name) 
+        ( name,
+          find ((== name) . takeFileName . toFilePath . itemIdentifier) before,
+          find ((== name) . takeFileName . toFilePath . itemIdentifier) after
+        )
+        | name <- allNames
+      ]
 
 lookupBy :: (a -> Maybe b) -> [a] -> Maybe b
 lookupBy f = listToMaybe . mapMaybe f

--- a/message-index/templates/message.html
+++ b/message-index/templates/message.html
@@ -15,8 +15,11 @@ $endif$
 $body$
 
 <h2>Examples</h2>
-<ul>
 $for(examples)$
-<li><a href="$url$">$title$</a></li>
+<details>
+  <summary>$title$</summary>
+  <div class="example-container">
+    $body$
+  </div>
+</details>
 $endfor$
-</ul>


### PR DESCRIPTION
This PR changes the way Examples are shown, from its own page into a collapsible panel in the message itself. And even better, this is done without any JavaScript, only pure HTML!

- Two folded examples ![imagen](https://user-images.githubusercontent.com/309334/173254246-32e443f6-8657-43a0-a13a-007b272133ae.png)
- One unfolded example ![imagen](https://user-images.githubusercontent.com/309334/173254214-0341e7e4-c44d-4a9f-89de-101f93cc1580.png)
