### PR TITLE
highlight inline code samples

### DIFF
--- a/message-index/css/default.css
+++ b/message-index/css/default.css
@@ -160,20 +160,17 @@ article .header {
   }
 }
 
-.example {
-  display: inline-block;
-  width: 45%;
-}
-
 main pre code {
   background-color: #fafafa;
-  font-family: monospace;
-  display: inline-block;
   padding: 10px;
 }
 
-.example pre {
-  overflow-x: scroll;
+main code {
+  background-color: #eaeaea;
+  font-family: monospace;
+  display: inline-block;
+  padding-left: 2px;
+  padding-right: 2px;
 }
 
 nav#breadcrumb {


### PR DESCRIPTION
also removes the unused .examples class

looks like this:

![image](https://user-images.githubusercontent.com/1651325/173334650-463f1a32-882f-4d09-90f3-a41ca7baade4.png)
