### PR TITLE
Style cleanup

### DIFF
--- a/message-index/messages/GHC-06446/index.md
+++ b/message-index/messages/GHC-06446/index.md
@@ -1,10 +1,10 @@
 ---
 title: Do notation in pattern match
-summary: Do notation in pattern match
+summary: Do notation in pattern match.
 severity: error
 introduced: 9.6.1
 ---
 
-When pattern matching, `do` blocks are not allowed as expressions to be pattern matched against.
+When pattern matching, `do` expressions are not allowed as patterns to be matched against.
 
 Instead, either match on a variable within the `do` block, or on the value the `do` block itself evaluates to.

--- a/message-index/messages/GHC-11861/example2/index.md
+++ b/message-index/messages/GHC-11861/example2/index.md
@@ -1,6 +1,5 @@
 ---
-title: Empty character literals
-summary: Incorrect TemplateHaskell syntax
+title: Incorrect TemplateHaskell syntax using ''
 introduced: 9.6.1
 severity: error
 ---

--- a/message-index/messages/GHC-11861/index.md
+++ b/message-index/messages/GHC-11861/index.md
@@ -1,14 +1,14 @@
 ---
-title: Empty single quotes 
-summary: No character literal provided within single quotes
+title: Empty single quotes
+summary: No character literal provided within single quotes.
 severity: error
 introduced: 9.6.1
 extension: TemplateHaskell
 ---
 
-Single quotes are used for character and literals including "new line" (\\n), "carriage return" (\\r), "horizontal tab" (\\t), and "vertical tab" (\\v). The complete list of character escapes is described in [the Haskell Report](https://www.haskell.org/onlinereport/lexemes.html) section 2.6, Character and String Literals. Character literals cannot be empty.
+Single quotes are used for character and literals including "new line" (`'\n'`), "carriage return" (`'\r'`), "horizontal tab" (`'\t'`), and "vertical tab" (`'\v'`). The complete list of character escapes is described in [the Haskell Report](https://www.haskell.org/onlinereport/lexemes.html) section 2.6, Character and String Literals. Character literals cannot be empty.
 
-Another usage of single quotes is in TemplateHaskell, please refer to the [GHC documentation](https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/template_haskell.html#syntax) for details.
+Another usage of single quotes is in `TemplateHaskell`; please refer to the [GHC documentation](https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/template_haskell.html#syntax) for details.
 
 ## Example error text
 

--- a/message-index/messages/GHC-45696/example1/index.md
+++ b/message-index/messages/GHC-45696/example1/index.md
@@ -2,7 +2,7 @@
 title: If-Then-Else in pattern match
 ---
 
-When pattern matching, `(if .. then .. else)` blocks are not allowed as expressions to be pattern matched against.
+When pattern matching, `(if .. then .. else)` expressions are not allowed as patterns to be matched against.
 
 In this example, if `a` is `True` then we want to pattern match `b` to `"something"`; if `a` is `False`, we want to pattern match `b` with `"something else"` instead. For instance, `f True "something else"` is `False` and `f False "something else"` is `True`.
 

--- a/message-index/messages/GHC-45696/index.md
+++ b/message-index/messages/GHC-45696/index.md
@@ -1,6 +1,6 @@
 ---
 title: If-Then-Else in pattern match
-summary: If-Then-Else in pattern match
+summary: If-Then-Else expression in pattern match.
 severity: error
 introduced: 9.6.1
 ---

--- a/message-index/messages/GHC-56538/index.md
+++ b/message-index/messages/GHC-56538/index.md
@@ -1,6 +1,6 @@
 ---
 title: Instance head is not headed by a class
-summary: A type class instance declaration is declared for something that is not a type class
+summary: A type class instance declaration is declared for something that is not a type class.
 introduced: 9.6.1
 severity: error
 ---

--- a/message-index/messages/GHC-62330/index.md
+++ b/message-index/messages/GHC-62330/index.md
@@ -1,6 +1,6 @@
 ---
 title: Underscores not allowed in float and integer literals
-summary: Float and integer literals cannot contain underscores
+summary: Float and integer literals cannot contain underscores.
 severity: error
 introduced: 9.6.1
 ---

--- a/message-index/messages/GHC-69158/index.md
+++ b/message-index/messages/GHC-69158/index.md
@@ -1,6 +1,6 @@
 ---
 title: Conflicting exports
-summary: Different identifiers with the same name are (re-)exported from the same module
+summary: Different identifiers with the same name are (re-)exported from the same module.
 introduced: 9.6.1
 severity: error
 ---

--- a/message-index/messages/GHC-69925/index.md
+++ b/message-index/messages/GHC-69925/index.md
@@ -1,6 +1,6 @@
 ---
 title: Illegal unboxed string literal in pattern
-summary: Illegal unboxed string literal in pattern
+summary: Illegal unboxed string literal in pattern.
 severity: error
 introduced: 9.6.1
 ---

--- a/message-index/messages/GHC-77037/index.md
+++ b/message-index/messages/GHC-77037/index.md
@@ -1,6 +1,6 @@
 ---
 title: No explicit import list
-summary: Items brought into scope are not listed explicitly
+summary: Items brought into scope are not listed explicitly.
 severity: warning
 flag: "-Wmissing-import-lists"
 introduced: 9.6.1

--- a/message-index/messages/GHC-84077/index.md
+++ b/message-index/messages/GHC-84077/index.md
@@ -1,6 +1,6 @@
 ---
 title: Type application without space
-summary:  Parsing error of type application.
+summary: A type application with @ does not have a space before.
 introduced: 9.6.1
 severity: error
 extension: TypeApplications


### PR DESCRIPTION
This primarily adds full-stops to the summaries and changes a couple of sentences to more grammatically nice sentences.

It also fixes the example titles in the empty quote, where both examples are just called "empty quote" (and the second one should be called about templatehaskell)