### PR TITLE
Do not use haskell action on GitHub workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,9 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up Haskell
-      uses: haskell/actions/setup@v2
-
     - name: Check out repo
       uses: actions/checkout@v3
       
@@ -25,9 +22,9 @@ jobs:
         path: |
           ~/.cabal/store
           message-index/dist-newstyle
-        key: cabal-cache-${{ github.sha }}
+        key: cabal-cache-0-${{ hashFiles('message-index/message-index.cabal') }}
         restore-keys: |
-          cabal-cache
+          cabal-cache-0
 
     - name: Update the Cabal index
       run: cabal update

--- a/.github/workflows/pullrequest-ci.yml
+++ b/.github/workflows/pullrequest-ci.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up Haskell
-      uses: haskell/actions/setup@v2
-
     - name: Check out repo
       uses: actions/checkout@v3
       
@@ -23,9 +20,9 @@ jobs:
         path: |
           ~/.cabal/store
           message-index/dist-newstyle
-        key: cabal-cache-${{ github.sha }}
+        key: cabal-cache-0-${{ hashFiles('message-index/message-index.cabal') }}
         restore-keys: |
-          cabal-cache
+          cabal-cache-0
 
     - name: Update the Cabal index
       run: cabal update


### PR DESCRIPTION
If this works, this should speed up our build times considerably. The previous action took around 2 minutes, out of which 1.30 minutes were spent on this. However, we loose control of which specific version of GHC/Cabal we are using, we simply go with the one in the Ubuntu runner.