### PR TITLE
Pointer cursor in example summary

### DIFF
--- a/message-index/css/default.css
+++ b/message-index/css/default.css
@@ -231,6 +231,10 @@ summary {
   font-weight: bold;
 }
 
+details > summary {
+  cursor: pointer;
+}
+
 .example-container {
   margin-left: 15px;
   margin-top: 10px;


### PR DESCRIPTION
Use a pointer cursor when hovering example summary (that is clickable and hides or shows the example)

Fixes #509