### PR TITLE
Reduce search delay

### DIFF
--- a/message-index/index.html
+++ b/message-index/index.html
@@ -31,7 +31,7 @@ $partial("templates/message-list.html")$
 var filtersConfig = {
     base_path: '/wrong-on-purpose/',
     auto_filter: {
-        delay: 500 //milliseconds
+        delay: 75 //milliseconds
     },
     single_filter: true
 };


### PR DESCRIPTION
Reduces the delay to 75ms. It still isn't instantaneous (hopefully not too jumpy), but the search doesn't feel actually slow anymore.

We can revise this number after using it as this for some time

Fixes #512